### PR TITLE
feat(relatorios): implementação da opção de impressão.

### DIFF
--- a/patec/pom.xml
+++ b/patec/pom.xml
@@ -24,6 +24,20 @@
 			<artifactId>mssql-jdbc</artifactId>
 			<version>12.6.1.jre11</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi</artifactId>
+			<version>5.2.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>5.2.5</version>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/patec/src/model/AlunoDAO.java
+++ b/patec/src/model/AlunoDAO.java
@@ -1,6 +1,9 @@
 package model;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import util.BD;
 
@@ -129,6 +132,35 @@ public class AlunoDAO {
 		}
 
 		return a;
+	}
+
+	public Map<Integer, Object> GerarRelatorioAluno(String ra) {
+		BD bd = new BD();
+		Map<Integer, Object> matrizDados = new HashMap<>();
+
+		String sql = "SELECT GABARITO_OFICIAL.codigo_disciplina, FOLHA_DE_RESPOSTAS.nota FROM FOLHA_DE_RESPOSTAS\r\n"
+				+ "JOIN GABARITO_OFICIAL ON FOLHA_DE_RESPOSTAS.codigo_gabarito = GABARITO_OFICIAL.cod_gabarito\r\n"
+				+ "WHERE FOLHA_DE_RESPOSTAS.ra = ?;";
+		bd.getConnection();
+		try {
+			bd.st = bd.con.prepareStatement(sql);
+			bd.st.setString(1, ra);
+			bd.rs = bd.st.executeQuery();
+			int i = 0;
+			while (bd.rs.next()) {
+				ArrayList<Object> vetorDados = new ArrayList<>();
+				vetorDados.add(bd.rs.getString("codigo_disciplina"));
+				vetorDados.add(bd.rs.getInt("nota"));
+				matrizDados.put(i, vetorDados);
+				i++;
+			}
+		} catch (Exception e) {
+			System.out.println(e);
+		} finally {
+			bd.close();
+		}
+
+		return matrizDados;
 	}
 
 }

--- a/patec/src/model/DisciplinaDAO.java
+++ b/patec/src/model/DisciplinaDAO.java
@@ -229,5 +229,37 @@ public class DisciplinaDAO {
 		}
 		return listaDisciplinas;
 	}
+	
+	public Map<Integer, Object> GerarRelatorioDisciplina(String nomeDisciplina) {
+		BD bd = new BD();
+		Map<Integer, Object> matrizDados = new HashMap<>();
+
+		String sql = "SELECT ALUNO.ra, ALUNO.nome_aluno, FOLHA_DE_RESPOSTAS.nota FROM FOLHA_DE_RESPOSTAS\r\n"
+				+ "JOIN ALUNO ON FOLHA_DE_RESPOSTAS.ra = ALUNO.ra\r\n"
+				+ "JOIN GABARITO_OFICIAL ON FOLHA_DE_RESPOSTAS.codigo_gabarito = GABARITO_OFICIAL.cod_gabarito\r\n"
+				+ "JOIN DISCIPLINA ON GABARITO_OFICIAL.codigo_disciplina = DISCIPLINA.cod_disciplina\r\n"
+				+ "WHERE DISCIPLINA.nome_disciplina = ?;";
+		bd.getConnection();
+		try {
+			bd.st = bd.con.prepareStatement(sql);
+			bd.st.setString(1, nomeDisciplina);
+			bd.rs = bd.st.executeQuery();
+			int i = 0;
+			while (bd.rs.next()) {
+				ArrayList<Object> vetorDados = new ArrayList<>();
+				vetorDados.add(bd.rs.getString("ra"));
+				vetorDados.add(bd.rs.getString("nome_aluno"));
+				vetorDados.add(bd.rs.getInt("nota"));
+				matrizDados.put(i, vetorDados);
+				i++;
+			}
+		} catch (Exception e) {
+			System.out.println(e);
+		} finally {
+			bd.close();
+		}
+
+		return matrizDados;
+	}
 
 }

--- a/patec/src/module-info.java
+++ b/patec/src/module-info.java
@@ -8,4 +8,6 @@ module patec {
 	requires java.desktop;
 	requires java.sql;
 	requires jdatepicker;
+	requires org.apache.poi.poi;
+	requires org.apache.poi.ooxml;
 }

--- a/patec/src/util/GeraPlanilhaRelatorio.java
+++ b/patec/src/util/GeraPlanilhaRelatorio.java
@@ -1,0 +1,110 @@
+package util;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.util.RegionUtil;
+
+public class GeraPlanilhaRelatorio {
+	public static void planilhaRelatorioAluno(Map<Integer, Object> matrizDados, String excelFilePath)
+			throws IOException {
+		Workbook workbook = new HSSFWorkbook();
+
+		Sheet sheet = workbook.createSheet();
+		sheet.setColumnWidth(1, 10 * 256);
+		sheet.setColumnWidth(2, 3 * 256);
+
+		int rowCount = 0;
+
+		for (int i = 0; i < matrizDados.size(); i++) {
+			Row row = sheet.createRow(++rowCount);
+			gravarDadosRelatorioAluno((ArrayList<Object>) matrizDados.get(i), row, sheet);
+		}
+
+		try (FileOutputStream outputStream = new FileOutputStream(excelFilePath)) {
+			workbook.write(outputStream);
+		}
+
+		workbook.close();
+	}
+
+	private static void gravarDadosRelatorioAluno(ArrayList<Object> dados, Row linha, Sheet sheet) {
+		for (int i = 0; i < 2; i++) {
+			Cell celula = linha.createCell(i + 1);
+
+			if (i == 0) {
+				celula.setCellValue((String) dados.get(0));
+			} else {
+				int nota = (int) dados.get(1);
+				celula.setCellValue(nota);
+			}
+
+			CellRangeAddress region = new CellRangeAddress(celula.getRowIndex(), celula.getRowIndex(),
+					celula.getColumnIndex(), celula.getColumnIndex());
+			RegionUtil.setBorderTop(BorderStyle.THIN, region, sheet);
+			RegionUtil.setBorderBottom(BorderStyle.THIN, region, sheet);
+			RegionUtil.setBorderLeft(BorderStyle.THIN, region, sheet);
+			RegionUtil.setBorderRight(BorderStyle.THIN, region, sheet);
+
+		}
+
+	}
+
+	public static void planilhaRelatorioDisciplina(Map<Integer, Object> matrizDados, String excelFilePath)
+			throws IOException {
+		Workbook workbook = new HSSFWorkbook();
+
+		Sheet sheet = workbook.createSheet();
+		sheet.setColumnWidth(1, 15 * 256);
+		sheet.setColumnWidth(2, 50 * 256);
+		sheet.setColumnWidth(3, 3 * 256);
+
+		int rowCount = 0;
+
+		for (int i = 0; i < matrizDados.size(); i++) {
+			Row row = sheet.createRow(++rowCount);
+			//System.out.println(row.getRowNum());
+			gravarDadosRelatorioDisciplina((ArrayList<Object>) matrizDados.get(i), row, sheet);
+		}
+
+		try (FileOutputStream outputStream = new FileOutputStream(excelFilePath)) {
+			workbook.write(outputStream);
+		}
+
+		workbook.close();
+	}
+
+	private static void gravarDadosRelatorioDisciplina(ArrayList<Object> dados, Row linha, Sheet sheet) {
+		for (int i = 0; i < 3; i++) {
+			Cell celula = linha.createCell(i + 1);
+
+			if (i == 0) {
+				celula.setCellValue((String) dados.get(0));
+			} else if (i == 1) {
+				celula.setCellValue((String) dados.get(1));
+			} else {
+				int nota = (int) dados.get(2);
+				celula.setCellValue(nota);
+			}
+
+			CellRangeAddress region = new CellRangeAddress(celula.getRowIndex(), celula.getRowIndex(),
+					celula.getColumnIndex(), celula.getColumnIndex());
+			RegionUtil.setBorderTop(BorderStyle.THIN, region, sheet);
+			RegionUtil.setBorderBottom(BorderStyle.THIN, region, sheet);
+			RegionUtil.setBorderLeft(BorderStyle.THIN, region, sheet);
+			RegionUtil.setBorderRight(BorderStyle.THIN, region, sheet);
+
+		}
+
+	}
+
+}

--- a/patec/src/util/ImprimirPlanilhaRelatorio.java
+++ b/patec/src/util/ImprimirPlanilhaRelatorio.java
@@ -1,0 +1,14 @@
+package util;
+
+import java.awt.Desktop;
+import java.io.File;
+
+public class ImprimirPlanilhaRelatorio {
+	public static void imprimeRelatorio(String excelFilePath) {
+		Desktop desktop = Desktop.getDesktop();
+		try {
+			desktop.print(new File(excelFilePath));
+		} catch (Exception e) {
+		}
+	}
+}

--- a/patec/src/view/PainelRelatorioAluno.java
+++ b/patec/src/view/PainelRelatorioAluno.java
@@ -1,16 +1,36 @@
 package view;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableModel;
 
 import model.Aluno;
 import model.AlunoDAO;
 import util.BD;
-import view.components.*;
+import util.GeraPlanilhaRelatorio;
+import util.ImprimirPlanilhaRelatorio;
+import view.components.BtnSair;
+import view.components.BtnVoltar;
+import view.components.MenuBarCoord;
+import view.components.TableModelPatec;
 
 public class PainelRelatorioAluno extends JPanel {
 
@@ -25,9 +45,9 @@ public class PainelRelatorioAluno extends JPanel {
 	 */
 	public PainelRelatorioAluno(Aluno a) {
 		GridBagLayout gridBagLayout = new GridBagLayout();
-		gridBagLayout.columnWidths = new int[] { 66, 0, 450, 0, 66, 0 };
+		gridBagLayout.columnWidths = new int[] { 66, 100, 450, 100, 66, 0 };
 		gridBagLayout.rowHeights = new int[] { 28, 0, 0, 272, 0, 0 };
-		gridBagLayout.columnWeights = new double[] { 0.0, 1.0, 1.0, 1.0, 0.0, Double.MIN_VALUE };
+		gridBagLayout.columnWeights = new double[] { 0.0, 0.0, 1.0, 0.0, 0.0, Double.MIN_VALUE };
 		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 1.0, 1.0, 1.0, Double.MIN_VALUE };
 		setLayout(gridBagLayout);
 
@@ -141,6 +161,33 @@ public class PainelRelatorioAluno extends JPanel {
 		tabelaRelatorioAluno.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		containerListaAlunos.setViewportView(tabelaRelatorioAluno);
 		tabelaRelatorioAluno.setFillsViewportHeight(true);
+
+		JButton btnImprimirRelatorioAluno = new JButton("Imprimir Relatório");
+		btnImprimirRelatorioAluno.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				Map<Integer, Object> matrizDados = dao.GerarRelatorioAluno(a.getRa());
+				try {
+					GeraPlanilhaRelatorio.planilhaRelatorioAluno(matrizDados, "spreadsheets/RelatorioAluno.xls");
+					ImprimirPlanilhaRelatorio.imprimeRelatorio("spreadsheets/RelatorioAluno.xls");
+
+				} catch (IOException e1) {
+					new File("spreadsheets").mkdir();
+					try {
+						GeraPlanilhaRelatorio.planilhaRelatorioAluno(matrizDados, "spreadsheets/RelatorioAluno.xls");
+						ImprimirPlanilhaRelatorio.imprimeRelatorio("spreadsheets/RelatorioAluno.xls");
+					} catch (IOException e2) {
+						e2.printStackTrace();
+					}
+				}
+
+			}
+		});
+		GridBagConstraints gbc_btnImprimirRelatorioAluno = new GridBagConstraints();
+		gbc_btnImprimirRelatorioAluno.anchor = GridBagConstraints.NORTHEAST;
+		gbc_btnImprimirRelatorioAluno.insets = new Insets(0, 0, 0, 5);
+		gbc_btnImprimirRelatorioAluno.gridx = 2;
+		gbc_btnImprimirRelatorioAluno.gridy = 4;
+		add(btnImprimirRelatorioAluno, gbc_btnImprimirRelatorioAluno);
 	}
 
 	private void carregarTabela(String ra) {

--- a/patec/src/view/PainelRelatorioDisciplina.java
+++ b/patec/src/view/PainelRelatorioDisciplina.java
@@ -6,6 +6,9 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -16,9 +19,11 @@ import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.table.DefaultTableModel;
 
-import model.Aluno;
+//import model.Aluno;
 import model.DisciplinaDAO;
 import util.BD;
+import util.GeraPlanilhaRelatorio;
+import util.ImprimirPlanilhaRelatorio;
 import view.components.BtnSair;
 import view.components.BtnVoltar;
 import view.components.MenuBarCoord;
@@ -37,9 +42,9 @@ public class PainelRelatorioDisciplina extends JPanel {
 	 */
 	public PainelRelatorioDisciplina(String nomeDisciplina) {
 		GridBagLayout gridBagLayout = new GridBagLayout();
-		gridBagLayout.columnWidths = new int[] { 66, 0, 450, 100, 66, 0 };
+		gridBagLayout.columnWidths = new int[] { 66, 100, 450, 100, 66, 0 };
 		gridBagLayout.rowHeights = new int[] { 28, 0, 0, 272, 0, 0 };
-		gridBagLayout.columnWeights = new double[] { 0.0, 1.0, 1.0, 1.0, 0.0, Double.MIN_VALUE };
+		gridBagLayout.columnWeights = new double[] { 0.0, 0.0, 1.0, 0.0, 0.0, Double.MIN_VALUE };
 		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 1.0, 1.0, 1.0, Double.MIN_VALUE };
 		setLayout(gridBagLayout);
 
@@ -110,6 +115,34 @@ public class PainelRelatorioDisciplina extends JPanel {
 		tabelaRelatorioAluno.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		containerListaAlunos.setViewportView(tabelaRelatorioAluno);
 		tabelaRelatorioAluno.setFillsViewportHeight(true);
+
+		JButton btnImprimirRelatorioDisciplina = new JButton("Imprimir Relatório");
+		btnImprimirRelatorioDisciplina.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				Map<Integer, Object> matrizDados = dao.GerarRelatorioDisciplina(nomeDisciplina);
+				try {
+					GeraPlanilhaRelatorio.planilhaRelatorioDisciplina(matrizDados,
+							"spreadsheets/RelatorioDisciplina.xls");
+					ImprimirPlanilhaRelatorio.imprimeRelatorio("spreadsheets/RelatorioDisciplina.xls");
+
+				} catch (IOException e1) {
+					new File("spreadsheets").mkdir();
+					try {
+						GeraPlanilhaRelatorio.planilhaRelatorioDisciplina(matrizDados,
+								"spreadsheets/RelatorioDisciplina.xls");
+						ImprimirPlanilhaRelatorio.imprimeRelatorio("spreadsheets/RelatorioDisciplina.xls");
+					} catch (IOException e2) {
+						e2.printStackTrace();
+					}
+				}
+			}
+		});
+		GridBagConstraints gbc_btnImprimirRelatorioDisciplina = new GridBagConstraints();
+		gbc_btnImprimirRelatorioDisciplina.anchor = GridBagConstraints.NORTHEAST;
+		gbc_btnImprimirRelatorioDisciplina.insets = new Insets(0, 0, 0, 5);
+		gbc_btnImprimirRelatorioDisciplina.gridx = 2;
+		gbc_btnImprimirRelatorioDisciplina.gridy = 4;
+		add(btnImprimirRelatorioDisciplina, gbc_btnImprimirRelatorioDisciplina);
 	}
 
 	private void carregarTabela(String nomeDisciplina) {
@@ -117,7 +150,7 @@ public class PainelRelatorioDisciplina extends JPanel {
 				+ "JOIN ALUNO ON FOLHA_DE_RESPOSTAS.ra = ALUNO.ra\r\n"
 				+ "JOIN GABARITO_OFICIAL ON FOLHA_DE_RESPOSTAS.codigo_gabarito = GABARITO_OFICIAL.cod_gabarito\r\n"
 				+ "JOIN DISCIPLINA ON GABARITO_OFICIAL.codigo_disciplina = DISCIPLINA.cod_disciplina\r\n"
-				+ "WHERE DISCIPLINA.nome_disciplina = '"+ nomeDisciplina + "';";
+				+ "WHERE DISCIPLINA.nome_disciplina = '" + nomeDisciplina + "';";
 		model = TableModelPatec.getModel(bd, sql);
 		tabelaRelatorioAluno.setModel(model);
 


### PR DESCRIPTION
Em ambas as telas de relatório, foi adicionado um botão que permite a impressão dos dados exibidos na tabela. Para isso, foi necessária a adição das dependências 'poi' e 'poi-ooxml' no pom.xml. Além disso, foram criadas duas classes no pacote 'util':
- GeraPlanilhaRelatorio
- ImprimirPlanilhaRelatorio

Foram adicionados dois métodos em AlunoDAO e DisciplinaDAO, respectivamente:
- gerarRelatorioAluno
- gerarRelatorioDisciplina

As planilhas geradas estarão na pasta 'spreadsheets'.